### PR TITLE
Add filter for completed/incomplete todos

### DIFF
--- a/TodoList/ContentView.swift
+++ b/TodoList/ContentView.swift
@@ -33,8 +33,16 @@ struct ContentView: View {
                 }
                 .padding()
                 
+                Picker("过滤", selection: $viewModel.currentFilter) {
+                    Text("全部").tag(TodoViewModel.FilterOption.all)
+                    Text("已完成").tag(TodoViewModel.FilterOption.completed)
+                    Text("未完成").tag(TodoViewModel.FilterOption.incomplete)
+                }
+                .pickerStyle(SegmentedPickerStyle())
+                .padding(.horizontal)
+                
                 List {
-                    ForEach(viewModel.todos) { todo in
+                    ForEach(viewModel.filteredTodos) { todo in
                         HStack {
                             Image(systemName: todo.isCompleted ? "checkmark.circle.fill" : "circle")
                                 .foregroundColor(todo.isCompleted ? .green : .gray)
@@ -50,6 +58,11 @@ struct ContentView: View {
                 }
             }
             .navigationTitle("待办事项")
+            .alert("错误", isPresented: $showingError) {
+                Button("确定", role: .cancel) { }
+            } message: {
+                Text(errorMessage)
+            }
         }
     }
 }

--- a/TodoList/ViewModels/TodoViewModel.swift
+++ b/TodoList/ViewModels/TodoViewModel.swift
@@ -3,6 +3,8 @@ import SwiftUI
 
 /// 待办事项视图模型
 /// 负责处理待办事项的业务逻辑和数据管理
+/// 使用 @Published 属性包装器实现数据绑定
+/// 使用 @StateObject 属性包装器实现视图模型实例的声明周期管理
 class TodoViewModel: ObservableObject {
     /// 待办事项列表，使用 @Published 属性包装器实现数据绑定
     @Published var todos: [Todo] = []

--- a/TodoList/ViewModels/TodoViewModel.swift
+++ b/TodoList/ViewModels/TodoViewModel.swift
@@ -7,6 +7,16 @@ class TodoViewModel: ObservableObject {
     /// 待办事项列表，使用 @Published 属性包装器实现数据绑定
     @Published var todos: [Todo] = []
     
+    /// 过滤选项
+    enum FilterOption {
+        case all
+        case completed
+        case incomplete
+    }
+    
+    /// 当前过滤选项
+    @Published var currentFilter: FilterOption = .all
+    
     /// 待办事项服务实例
     private let todoService: TodoServiceProtocol
     
@@ -49,5 +59,17 @@ class TodoViewModel: ObservableObject {
     /// 保存待办事项到持久化存储
     private func saveTodos() {
         todoService.saveTodos(todos)
+    }
+    
+    /// 根据当前过滤选项获取过滤后的待办事项列表
+    var filteredTodos: [Todo] {
+        switch currentFilter {
+        case .all:
+            return todos
+        case .completed:
+            return todos.filter { $0.isCompleted }
+        case .incomplete:
+            return todos.filter { !$0.isCompleted }
+        }
     }
 } 

--- a/TodoListTests/TodoViewModelTests.swift
+++ b/TodoListTests/TodoViewModelTests.swift
@@ -71,6 +71,49 @@ final class TodoViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.todos[0].title, "测试项目1")
         XCTAssertEqual(viewModel.todos[1].title, "测试项目2")
     }
+    
+    // MARK: - 过滤功能测试
+    
+    func testFilterAll() {
+        // Given
+        viewModel.addTodo(title: "已完成项目")
+        viewModel.addTodo(title: "未完成项目")
+        viewModel.toggleTodoCompletion(todo: viewModel.todos[0])
+        
+        // When
+        viewModel.currentFilter = .all
+        
+        // Then
+        XCTAssertEqual(viewModel.filteredTodos.count, 2)
+    }
+    
+    func testFilterCompleted() {
+        // Given
+        viewModel.addTodo(title: "已完成项目")
+        viewModel.addTodo(title: "未完成项目")
+        viewModel.toggleTodoCompletion(todo: viewModel.todos[0])
+        
+        // When
+        viewModel.currentFilter = .completed
+        
+        // Then
+        XCTAssertEqual(viewModel.filteredTodos.count, 1)
+        XCTAssertEqual(viewModel.filteredTodos[0].title, "已完成项目")
+    }
+    
+    func testFilterIncomplete() {
+        // Given
+        viewModel.addTodo(title: "已完成项目")
+        viewModel.addTodo(title: "未完成项目")
+        viewModel.toggleTodoCompletion(todo: viewModel.todos[0])
+        
+        // When
+        viewModel.currentFilter = .incomplete
+        
+        // Then
+        XCTAssertEqual(viewModel.filteredTodos.count, 1)
+        XCTAssertEqual(viewModel.filteredTodos[0].title, "未完成项目")
+    }
 }
 
 // MARK: - Mock Service


### PR DESCRIPTION
This PR adds a segmented control and ViewModel logic to filter all/completed/incomplete tasks.
![image1](https://github.com/user-attachments/assets/757c0523-2da4-4f7e-9511-3ab5845bd3c9)
